### PR TITLE
Load local configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -318,5 +318,9 @@ doc/*.htm
 AssetsServer/Data/
 AssetsServer/Assets/
 
+# Ignore local override config
+*.[Ll]ocal.cs
+appsettings.local.json
+
 .claude/settings.local.json
 ServerPackets/

--- a/Client.Main/Client.Main.csproj
+++ b/Client.Main/Client.Main.csproj
@@ -38,6 +38,18 @@
     <PackageReference Include="NLayer" Version="1.16.0" />
   </ItemGroup>
 
+  <!-- LOCAL CONFIG FILE -->
+  <!-- Remove automatic compile of file -->
+  <ItemGroup>
+    <Compile Remove="Constants*.cs" />
+  </ItemGroup>
+  <!-- Add it back with condition -->
+  <ItemGroup>
+    <Compile Include="Constants.Local.cs" Condition="Exists('Constants.Local.cs')" />
+    <Compile Include="Constants.cs" Condition="!Exists('Constants.Local.cs')" />
+  </ItemGroup>
+  <!-- LOCAL CONFIG FILE END -->
+
   <!-- appsettings.json -->
   <ItemGroup Condition="'$(TargetFramework)'=='net9.0-android'">
     <AndroidAsset Include="appsettings.json" />
@@ -53,6 +65,9 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'!='net9.0-android'">
     <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.local.json" Condition="Exists('appsettings.local.json')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Client.Main/MuGame.cs
+++ b/Client.Main/MuGame.cs
@@ -216,6 +216,7 @@ namespace Client.Main
             AppConfiguration = new ConfigurationBuilder()
                 .SetBasePath(AppContext.BaseDirectory)
                 .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .AddJsonFile("appsettings.local.json", optional: true, reloadOnChange: true)
                 .Build();
 #endif
 


### PR DESCRIPTION
It will affect two config file at Client.Main project:

- Constants.cs  
- appsettings.json  

Added Constants.Local.cs and appsettings.local.json

> if Constants.Local.cs file exists it will load Constants.Local.cs file instead of Constants.cs file
> if appsettings.local.json file exists it will also merge config from appsettings.local.json  

So if you setup your project locally, just make a new copy of there file then add .local suffix to the file name
then modify your settings just for your environment 
